### PR TITLE
Show side panel by default

### DIFF
--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -46,6 +46,6 @@ export default class AppContainer extends Component {
 
   render() {
     console.log(this.state.imageURL);
-    return <App imageURL={this.state.imageURL} />
+    return <App imageURL={this.state.imageURL} showSidePanel={true} />
   }
 }


### PR DESCRIPTION
When I made a fresh clone of the repo, it appeared that the side panel was not showing up. I discovered that in `AppContainer.js`, `App` was not receiving the prop `showSidePanel`. Added this prop in and set it to `true`. 